### PR TITLE
add event to decision

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -124,7 +124,7 @@ module.exports =
     firstInstall = localStorage.getItem('autocomplete-python.installed') == null
     localStorage.setItem('autocomplete-python.installed', true)
 
-    longRunning = require('process').uptime() > 60
+    longRunning = require('process').uptime() > 10
     event = if firstInstall then "installed" else (if longRunning then "upgraded" else "restarted")
     console.log event
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -121,7 +121,7 @@ module.exports =
   activate: (state) ->
     require('./provider').constructor()
 
-    firstInstall = localStorage.getItem('autocomplete-python.installed') === null
+    firstInstall = localStorage.getItem('autocomplete-python.installed') == null
     localStorage.setItem('autocomplete-python.installed', true)
     longRunning = require('process').uptime() > 10
     if firstInstall and longRunning

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -150,7 +150,7 @@ module.exports =
       if not atom.config.get 'pluggy-mcpluginface.useKite'
         return
       canInstall = StateController.canInstallKite()
-      throttle = dm.canInstallKite(event)
+      throttle = dm.shouldOfferKite(event)
       Promise.all([throttle, canInstall]).then((values) =>
         atom.config.set 'pluggy-mcpluginface.useKite', true
         variant = values[0]

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -126,7 +126,6 @@ module.exports =
 
     longRunning = require('process').uptime() > 10
     event = if firstInstall then "installed" else (if longRunning then "upgraded" else "restarted")
-    console.log event
 
     {
       AccountManager,

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -121,11 +121,15 @@ module.exports =
   activate: (state) ->
     require('./provider').constructor()
 
-    firstInstall = localStorage.getItem('autocomplete-python.installed') == null
+    firstInstall = localStorage.getItem('autocomplete-python.installed') === null
     localStorage.setItem('autocomplete-python.installed', true)
-
     longRunning = require('process').uptime() > 10
-    event = if firstInstall then "installed" else (if longRunning then "upgraded" else "restarted")
+    if firstInstall and longRunning
+      event = "installed"
+    else if firstInstall
+      event = "upgraded"
+    else
+      event = "restarted"
 
     {
       AccountManager,

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -121,6 +121,13 @@ module.exports =
   activate: (state) ->
     require('./provider').constructor()
 
+    firstInstall = localStorage.getItem('autocomplete-python.installed') == null
+    localStorage.setItem('autocomplete-python.installed', true)
+
+    longRunning = require('process').uptime() > 60
+    event = if firstInstall then "installed" else (if longRunning then "upgraded" else "restarted")
+    console.log event
+
     {
       AccountManager,
       AtomHelper,
@@ -143,7 +150,7 @@ module.exports =
       if not atom.config.get 'pluggy-mcpluginface.useKite'
         return
       canInstall = StateController.canInstallKite()
-      throttle = dm.canInstallKite()
+      throttle = dm.canInstallKite(event)
       Promise.all([throttle, canInstall]).then((values) =>
         atom.config.set 'pluggy-mcpluginface.useKite', true
         variant = values[0]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",
-    "kite-installer": "^0.0.38",
+    "kite-installer": "^0.1.0",
     "selector-kit": "^0.1",
     "space-pen": "^5.1.2",
     "underscore": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",
-    "kite-installer": ">=0.0.38",
+    "kite-installer": "^0.0.38",
     "selector-kit": "^0.1",
     "space-pen": "^5.1.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
@dhung09 @intrepidlemon 

This pr uses process uptime and a localStorage var to set the event parameter for the decision endpoint.

It also sets the version for `kite-installer` to `0.1.0` so that we can push non-breaking bug fixes as patches, but we can also bump the minor version to break backwards compatibility.