### PR TITLE
Fix Auto-insert Single Suggestion Bug

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -321,6 +321,7 @@ module.exports =
   setSnippetsManager: (@snippetsManager) ->
 
   _completeArguments: (editor, bufferPosition, force) ->
+    return if atom.config.get 'autocomplete-python.useKite'
     useSnippets = atom.config.get('autocomplete-python.useSnippets')
     if not force and useSnippets == 'none'
       atom.commands.dispatch(document.querySelector('atom-text-editor'),


### PR DESCRIPTION
It looks like `completeArguments` is only useful if Kite is not the preferred provider, since the Kite Atom plugin internally filters all suggestions from autocomplete-python when inside `()`.

Inside this function call, a manual activation event is emitted, causing suggestions with a single entry to be automatically inserted into the buffer, even when undesired. Adding an early return if we detect that Kite is the preferred provider resolves this behavior.